### PR TITLE
Update german overview chapter

### DIFF
--- a/presentation/chapters/de-DE/overview.chapter
+++ b/presentation/chapters/de-DE/overview.chapter
@@ -92,7 +92,7 @@ Viele Beispiele in diesem Kurs sind sehr klein, daher werden wir immer auch etwa
 
 ## Schnell
 
--   Obige Eigenschaften werden zur Kompilierzeit garantiert und haben keine Laufzeitkosten!
+-   Die zuvor genannten Eigenschaften werden zur Kompilierzeit garantiert und haben keine Laufzeitkosten!
 -   Optimierender Compiler basierend auf LLVM
 -   Features mit Laufzeitkosten sind explizit und werden nicht "aus Versehen" aktiviert
 -   Keine Reflektion (Vampirsprache)


### PR DESCRIPTION
`Obige` does not make sense while looking at the slides. This change makes it a bit more understandable, which features are meant.